### PR TITLE
Added postprocessor for Fanuc robots (LS Format)

### DIFF
--- a/src/Robots.Grasshopper/Commands/CustomCommand.cs
+++ b/src/Robots.Grasshopper/Commands/CustomCommand.cs
@@ -10,7 +10,7 @@ public class CustomCommand : GH_Component
     protected override void RegisterInputParams(GH_InputParamManager pManager)
     {
         pManager.AddTextParameter("Name", "N", "Name", GH_ParamAccess.item, "CustomCommand");
-        pManager.AddTextParameter("Manufacturer", "M", "Robot manufacturer, options:  ABB, KUKA, UR, Staubli, FrankaEmika, Doosan, Other, All. If you select 'All', the command will always be included irrespective of the manufacturer.", GH_ParamAccess.item, "All");
+        pManager.AddTextParameter("Manufacturer", "M", "Robot manufacturer, options:  ABB, KUKA, UR, Staubli, FrankaEmika, Doosan, Fanuc, Other, All. If you select 'All', the command will always be included irrespective of the manufacturer.", GH_ParamAccess.item, "All");
         pManager.AddTextParameter("Code", "C", "Command code", GH_ParamAccess.item);
         pManager.AddTextParameter("Declaration", "D", "Variable declaration and assignment", GH_ParamAccess.item);
         pManager[2].Optional = true;

--- a/src/Robots.Grasshopper/Obsolete/Custom.cs
+++ b/src/Robots.Grasshopper/Obsolete/Custom.cs
@@ -34,8 +34,8 @@ public class Custom : GH_Component
     protected override void SolveInstance(IGH_DataAccess DA)
     {
         string? name = null;
-        string? abbDeclaration = null, kukaDeclaration = null, urDeclaration = null;
-        string? abbCode = null, kukaCode = null, urCode = null;
+        string? abbDeclaration = null, kukaDeclaration = null, urDeclaration = null, fanucDeclaration = null;
+        string? abbCode = null, kukaCode = null, urCode = null, fanucCode = null;
 
         if (!DA.GetData(0, ref name) || name is null) { return; }
         DA.GetData(1, ref abbDeclaration);
@@ -44,11 +44,13 @@ public class Custom : GH_Component
         DA.GetData(4, ref abbCode);
         DA.GetData(5, ref kukaCode);
         DA.GetData(6, ref urCode);
+        DA.GetData(7, ref fanucCode);
 
         var command = new Robots.Commands.Custom(name);
         command.AddCommand(Manufacturers.ABB, abbCode, abbDeclaration);
         command.AddCommand(Manufacturers.KUKA, kukaCode, kukaDeclaration);
         command.AddCommand(Manufacturers.UR, urCode, urDeclaration);
+        command.AddCommand(Manufacturers.Fanuc, fanucCode, fanucDeclaration);
 
         DA.SetData(0, new GH_Command(command));
     }

--- a/src/Robots.Grasshopper/Obsolete/Custom.cs
+++ b/src/Robots.Grasshopper/Obsolete/Custom.cs
@@ -34,8 +34,8 @@ public class Custom : GH_Component
     protected override void SolveInstance(IGH_DataAccess DA)
     {
         string? name = null;
-        string? abbDeclaration = null, kukaDeclaration = null, urDeclaration = null, fanucDeclaration = null;
-        string? abbCode = null, kukaCode = null, urCode = null, fanucCode = null;
+        string? abbDeclaration = null, kukaDeclaration = null, urDeclaration = null;
+        string? abbCode = null, kukaCode = null, urCode = null;
 
         if (!DA.GetData(0, ref name) || name is null) { return; }
         DA.GetData(1, ref abbDeclaration);
@@ -44,13 +44,11 @@ public class Custom : GH_Component
         DA.GetData(4, ref abbCode);
         DA.GetData(5, ref kukaCode);
         DA.GetData(6, ref urCode);
-        DA.GetData(7, ref fanucCode);
 
         var command = new Robots.Commands.Custom(name);
         command.AddCommand(Manufacturers.ABB, abbCode, abbDeclaration);
         command.AddCommand(Manufacturers.KUKA, kukaCode, kukaDeclaration);
         command.AddCommand(Manufacturers.UR, urCode, urDeclaration);
-        command.AddCommand(Manufacturers.Fanuc, fanucCode, fanucDeclaration);
 
         DA.SetData(0, new GH_Command(command));
     }

--- a/src/Robots/Commands/Message.cs
+++ b/src/Robots/Commands/Message.cs
@@ -12,6 +12,7 @@ public class Message(string message) : Command
         _commands.Add(Manufacturers.Staubli, (_, _) => $"putln(\"{_message}\")");
         _commands.Add(Manufacturers.FrankaEmika, (_, _) => $"print(\"{_message}\")");
         _commands.Add(Manufacturers.Doosan, (_, _) => $"tp_log(\"{_message}\")");
+        _commands.Add(Manufacturers.Fanuc, (_, _) => $":MESSAGE[\"{_message}\"] ;");
     }
 
     public override string ToString() => $"Command (Message \"{_message}\")";

--- a/src/Robots/Commands/PulseDO.cs
+++ b/src/Robots/Commands/PulseDO.cs
@@ -18,6 +18,7 @@ public class PulseDO(int @do, double length = 0.2) : Command
         _commands.Add(Manufacturers.KUKA, CodeKuka);
         _commands.Add(Manufacturers.UR, CodeUR);
         _commands.Add(Manufacturers.Doosan, CodeDoosan);
+        _commands.Add(Manufacturers.Fanuc, CodeFanuc);
 
         _declarations.Add(Manufacturers.UR, DeclarationUR);
     }
@@ -61,6 +62,12 @@ public class PulseDO(int @do, double length = 0.2) : Command
     {
         var number = GetNumber(robotSystem);
         return $"set_digital_output({number}, ON, {_length:0.###}, OFF)";
+    }
+
+    string CodeFanuc(RobotSystem robotSystem, Target target)
+    {
+        var number = GetNumber(robotSystem);
+        return $":DO[{number}]=PULSE, {_length:0.###}sec ;";
     }
 
     string GetNumber(RobotSystem robotSystem)

--- a/src/Robots/Commands/SetAO.cs
+++ b/src/Robots/Commands/SetAO.cs
@@ -18,6 +18,7 @@ public class SetAO(int ao, double value) : Command
         _commands.Add(Manufacturers.UR, CodeUR);
         _commands.Add(Manufacturers.Staubli, CodeStaubli);
         _commands.Add(Manufacturers.Doosan, CodeDoosan);
+        _commands.Add(Manufacturers.Fanuc, CodeFanuc);
 
         _declarations.Add(Manufacturers.ABB, DeclarationAbb);
         _declarations.Add(Manufacturers.KUKA, DeclarationKuka);
@@ -84,6 +85,12 @@ public class SetAO(int ao, double value) : Command
     {
         var number = GetNumber(robotSystem);
         return $"set_analog_output(ch={number}, val={Name})";
+    }
+
+    string CodeFanuc(RobotSystem robotSystem, Target target)
+    {
+        var number = GetNumber(robotSystem);
+        return $":AO[{number}]={Value} ;";
     }
 
     string GetNumber(RobotSystem robotSystem)

--- a/src/Robots/Commands/SetDO.cs
+++ b/src/Robots/Commands/SetDO.cs
@@ -18,6 +18,7 @@ public class SetDO(int @do, bool value) : Command
         _commands.Add(Manufacturers.UR, CodeUR);
         _commands.Add(Manufacturers.Staubli, CodeStaubli);
         _commands.Add(Manufacturers.Doosan, CodeDoosan);
+        _commands.Add(Manufacturers.Fanuc, CodeFanuc);
     }
 
     string CodeAbb(RobotSystem robotSystem, Target target)
@@ -64,6 +65,14 @@ public class SetDO(int @do, bool value) : Command
 
         string textValue = Value ? "ON" : "OFF";
         return $"set_digital_output({number}, {textValue})";
+    }
+
+    string CodeFanuc(RobotSystem robotSystem, Target target)
+    {
+        var number = GetNumber(robotSystem);
+
+        string textValue = Value ? "ON" : "OFF";
+        return $":DO[{number}]={textValue} ;";
     }
 
     string GetNumber(RobotSystem robotSystem)

--- a/src/Robots/Commands/Stop.cs
+++ b/src/Robots/Commands/Stop.cs
@@ -11,6 +11,7 @@ public class Stop : Command
         _commands.Add(Manufacturers.UR, (_, _) => "pause program");
         _commands.Add(Manufacturers.Doosan, (_, _) => "wait_nudge()");
         //_commands.Add(Manufacturers.Staubli, (_, __) => "wait(true)");
+        _commands.Add(Manufacturers.Fanuc, (_, _) => ":ABORT ;");
     }
 
     public override string ToString() => "Command (Stop)";

--- a/src/Robots/Commands/Wait.cs
+++ b/src/Robots/Commands/Wait.cs
@@ -12,6 +12,7 @@ public class Wait(double seconds) : Command
         _commands.Add(Manufacturers.Staubli, CodeStaubli);
         _commands.Add(Manufacturers.FrankaEmika, CodePython);
         _commands.Add(Manufacturers.Doosan, CodeDoosan);
+        _commands.Add(Manufacturers.Fanuc, CodeFanuc);
 
         _declarations.Add(Manufacturers.ABB, DeclarationAbb);
         _declarations.Add(Manufacturers.KUKA, DeclarationKuka);
@@ -70,6 +71,11 @@ public class Wait(double seconds) : Command
     string CodeDoosan(RobotSystem robotSystem, Target target)
     {
         return $"wait({Name})";
+    }
+
+    string CodeFanuc(RobotSystem robotSystem, Target target)
+    {
+        return $":WAIT {Seconds:0.00}(sec) ;";
     }
 
     public override string ToString() => $"Command (Wait {Seconds} secs)";

--- a/src/Robots/Commands/WaitDI.cs
+++ b/src/Robots/Commands/WaitDI.cs
@@ -18,6 +18,7 @@ public class WaitDI(int di, bool value = true) : Command
         _commands.Add(Manufacturers.UR, CodeUR);
         _commands.Add(Manufacturers.Staubli, CodeStaubli);
         _commands.Add(Manufacturers.Doosan, CodeDoosan);
+        _commands.Add(Manufacturers.Fanuc, CodeFanuc);
     }
 
     string CodeAbb(RobotSystem robotSystem, Target target)
@@ -54,6 +55,14 @@ public class WaitDI(int di, bool value = true) : Command
         var number = GetNumber(robotSystem);
         var value = Value ? "ON" : "OFF";
         return $"wait_digital_input({number}, {value})";
+    }
+
+    string CodeFanuc(RobotSystem robotSystem, Target target)
+    {
+        var number = GetNumber(robotSystem);
+        if (value) { return $":WAIT (DI[{number}]) ;"; }
+        else{ return $":WAIT (!DI[{number}]) ;"; }
+        
     }
 
     string GetNumber(RobotSystem robotSystem)

--- a/src/Robots/IO/FileIO.cs
+++ b/src/Robots/IO/FileIO.cs
@@ -167,6 +167,7 @@ public static class FileIO
             Manufacturers.Staubli => new SystemStaubli(name, mechanicalGroups, io, basePlane, environment),
             Manufacturers.FrankaEmika => new SystemFranka(name, (RobotFranka)mechanicalGroups[0].Robot, io, basePlane, environment),
             Manufacturers.Doosan => new SystemDoosan(name, (RobotDoosan)mechanicalGroups[0].Robot, io, basePlane, environment),
+            Manufacturers.Fanuc => new SystemFanuc(name, mechanicalGroups, io, basePlane, environment),
 
             _ => throw new ArgumentException($" Manufacturer '{manufacturer} is not supported.")
         };
@@ -241,6 +242,7 @@ public static class FileIO
                 Manufacturers.Staubli => new RobotStaubli(model, payload, basePlane, baseMesh, joints),
                 Manufacturers.FrankaEmika => new RobotFranka(model, payload, basePlane, baseMesh, joints),
                 Manufacturers.Doosan => new RobotDoosan(model, payload, basePlane, baseMesh, joints),
+                Manufacturers.Fanuc => new RobotFanuc(model, payload, basePlane, baseMesh, joints),
                 _ => throw new ArgumentException($" Manufacturer '{manufacturer}' not supported."),
             },
             "Positioner" => new Positioner(model, manufacturer, payload, basePlane, baseMesh, joints, movesRobot),

--- a/src/Robots/PostProcessors/FanucPostProcessor.cs
+++ b/src/Robots/PostProcessors/FanucPostProcessor.cs
@@ -1,0 +1,261 @@
+using Kdl;
+using Rhino.Geometry;
+using System;
+using System.CodeDom;
+using static System.Math;
+
+namespace Robots;
+
+class FanucPostProcessor
+{
+    readonly SystemFanuc _system;
+    readonly Program _program;
+
+    internal List<List<List<string>>> Code { get; }
+    internal int lineCount;
+
+    internal FanucPostProcessor(SystemFanuc system, Program program)
+    {
+        _system = system;
+        _program = program;
+        Code = [];
+
+        for (int i = 0; i < _system.MechanicalGroups.Count; i++)
+        {
+            var groupCode = new List<List<string>>
+            {
+                MainModule(i)
+            };
+
+            for (int j = 0; j < program.MultiFileIndices.Count; j++)
+                groupCode.Add(SubModule(j, i));
+
+            Code.Add(groupCode);
+        }
+    }
+
+    List<string> MainModule(int group)
+    {
+
+        var code = new List<string>();
+        bool multiProgram = _program.MultiFileIndices.Count > 1;
+
+        // Program Name - Has to be the same as the program filename
+        code.Add($"/PROG {_program.Name}");
+
+        // Attribute declarations - OPTIONAL
+        code.Add($"/ATTR");
+        code.Add($"COMMENT = \"Fanuc LS code\" ;");
+        var attributes = _program.Attributes;
+
+        // Main program - Required
+        {
+            code.Add($"/MN");
+
+            foreach (var tool in attributes.OfType<Tool>().Where(t => !t.UseController))
+            {
+                foreach (string codeLine in Tool(tool))
+                    code.Add($": {codeLine}");
+            }
+
+            foreach (var command in attributes.OfType<Command>())
+            {
+                string declaration = command.Declaration(_program);
+
+                if (!string.IsNullOrWhiteSpace(declaration))
+                    code.Add(declaration);
+            }
+        }
+
+        // Init commands
+
+        if (group == 0)
+        {
+            foreach (var command in _program.InitCommands)
+                code.Add(command.Code(_program, Target.Default));
+        }
+
+        if (multiProgram)
+        {
+            for (int i = 0; i < _program.MultiFileIndices.Count; i++)
+            {
+                code.Add($": CALL {_program.Name}_{i:000} ;");
+            }
+        }
+
+        if (multiProgram)
+        {
+            code.Add("/END");
+            code.Add("");
+        }
+
+        return code;
+    }
+
+    List<string> SubModule(int file, int group)
+    {
+        bool multiProgram = _program.MultiFileIndices.Count > 1;
+        string groupName = _system.MechanicalGroups[group].Name;
+
+        int start = _program.MultiFileIndices[file];
+        int end = (file == _program.MultiFileIndices.Count - 1) ? _program.Targets.Count : _program.MultiFileIndices[file + 1];
+        var code = new List<string>();
+        var codeMain = new List<string>();
+        if (multiProgram)
+        {
+            code.Add($"/PROG {_program.Name}_{file:000}");
+            code.Add($"/ATTR");
+            code.Add($"COMMENT = \"Fanuc sequence\";");
+            code.Add($"/MN");
+        }
+
+        int pointCounter = 1;
+        var pointsText = new List<String>();
+        for (int j = start; j < end; j++)
+        {
+            var programTarget = _program.Targets[j].ProgramTargets[group];
+            var target = programTarget.Target;
+            string moveText;
+            string zone = (target.Zone.IsFlyBy ? $"CNT{target.Zone.Distance}" : "FINE").NotNull(" Zone name cannot be null.");
+
+            if (programTarget.IsJointTarget)
+            {
+                var jointTarget = (JointTarget)programTarget.Target;
+                double[] joints = jointTarget.Joints;
+                joints = joints.Map((x, i) => _system.MechanicalGroups[group].RadianToDegree(x, i));
+                joints[2] -= joints[1];
+
+                moveText = $"J P[{pointCounter}] {target.Speed.TranslationSpeed:0}% {zone} ;";
+
+                pointsText.Add($"P[{pointCounter}]{{");
+                pointsText.Add($"   GP1:");
+                pointsText.Add($"    UF : 0, UT : 1,");
+                pointsText.Add($"   J1  =  {joints[0],9:0.000} deg,   J2  =  {joints[1],9:0.000} deg,   J3  =  {joints[2],9:0.000} deg,");
+                pointsText.Add($"   J4  =  {joints[3],9:0.000} deg,   J5  =  {joints[4],9:0.000} deg,   J6  =  {joints[5],9:0.000} deg");
+                pointsText.Add($"}};");
+
+                pointCounter++;
+            }
+            else
+            {
+                var cartesian = (CartesianTarget)programTarget.Target;
+                var plane = cartesian.Plane;
+                var planeValues = _system.PlaneToNumbers(plane);
+
+                switch (cartesian.Motion)
+                {
+                    case Motions.Joint:
+                        {
+                            RobotConfigurations configuration = programTarget.Kinematics.Configuration;
+                            bool shoulder = configuration.HasFlag(RobotConfigurations.Shoulder);
+                            bool elbow = configuration.HasFlag(RobotConfigurations.Elbow);
+                            if (shoulder) elbow = !elbow;
+                            bool wrist = configuration.HasFlag(RobotConfigurations.Wrist);
+
+                            string cfw = (wrist ? "F" : "N");
+                            string cfe = (elbow ? "D" : "U");
+                            string cfb = (shoulder ? "B" : "T");
+
+                            moveText = $"J P[{pointCounter}] {target.Speed.TranslationSpeed:0}% {zone} ;";
+
+                            pointsText.Add($"P[{pointCounter}]{{");
+                            pointsText.Add($"   GP1:");
+                            pointsText.Add($"    UF : 0, UT : 1,        CONFIG : '{cfw} {cfe} {cfb}, 0, 0, 0',");
+                            pointsText.Add($"   X  =  {planeValues[0],9:0.000}  mm,   Y  =  {planeValues[1],9:0.000}  mm,   Z  =  {planeValues[2],9:0.000}  mm,");
+                            pointsText.Add($"   W  =  {planeValues[5],9:0.000} deg,   P  =  {planeValues[4],9:0.000} deg,   R  =  {planeValues[3],9:0.000} deg");
+                            pointsText.Add($"}};");
+
+                            pointCounter++;
+                            break;
+                        }
+
+                    case Motions.Linear:
+                        {
+                            RobotConfigurations configuration = programTarget.Kinematics.Configuration;
+                            bool shoulder = configuration.HasFlag(RobotConfigurations.Shoulder);
+                            bool elbow = configuration.HasFlag(RobotConfigurations.Elbow);
+                            if (shoulder) elbow = !elbow;
+                            bool wrist = configuration.HasFlag(RobotConfigurations.Wrist);
+
+                            string cfw = (wrist ? "F" : "N");
+                            string cfe = (elbow ? "D" : "U");
+                            string cfb = (shoulder ? "B" : "T");
+
+                            moveText = $"L P[{pointCounter}] {target.Speed.TranslationSpeed:0}mm/sec {zone}  ;";
+
+                            pointsText.Add($"P[{pointCounter}]{{");
+                            pointsText.Add($"   GP1:");
+                            pointsText.Add($"    UF : 0, UT : 1,        CONFIG : '{cfw} {cfe} {cfb}, 0, 0, 0',");
+                            pointsText.Add($"   X  =  {planeValues[0],9:0.000}  mm,   Y  =  {planeValues[1],9:0.000}  mm,   Z  =  {planeValues[2],9:0.000}  mm,");
+                            pointsText.Add($"   W  =  {planeValues[5],9:0.000} deg,   P  =  {planeValues[4],9:0.000} deg,   R  =  {planeValues[3],9:0.000} deg");
+                            pointsText.Add($"}};");
+
+                            pointCounter++;
+                            break;
+                        }
+                    default:
+                        throw new ArgumentException($" Motion '{cartesian.Motion}' not supported.");
+                }
+            }
+
+            foreach (var command in programTarget.Commands.Where(c => c.RunBefore))
+                code.Add($":{command.Code(_program, target)}");
+
+            code.Add($":{moveText}");
+
+            foreach (var command in programTarget.Commands.Where(c => !c.RunBefore))
+                code.Add($":{command.Code(_program, target)}");
+            
+
+        }
+
+        code.Add("/POS");
+        foreach (var pointCodeLine in pointsText)
+            code.Add(pointCodeLine);
+        code.Add("/END");
+        code.Add("");
+
+        return code;
+    }
+
+    List<string> Tool(Tool tool)
+    {
+        var ToolCode = new List<string>();
+        var tcp = tool.Tcp;
+
+        var values = _system.PlaneToNumbers(tcp);
+
+        double weight = (tool.Weight > 0.001) ? tool.Weight : 0.001;
+
+        Point3d centroid = tool.Centroid;
+        if (centroid.DistanceTo(Point3d.Origin) < 0.001)
+            centroid = new Point3d(0, 0, 0.001);
+
+        ToolCode.Add($"UTOOL_NUM=1 ;");
+        ToolCode.Add($"! Tool 1 TCP Configuration ;");
+        ToolCode.Add($"! X: {-1*values[0]:0.000}, Y:{values[1]:0.000}, Z: {values[2]:0.000} ;");
+        ToolCode.Add($"! W: {values[5]:0.000}, P:{values[4]:0.000}, R: {-1*values[3]:0.000} ;");
+
+        return ToolCode;
+    }
+
+    List<string> Frame(Frame frame)
+    {
+        Plane plane = frame.Plane;
+        plane.InverseOrient(ref _system.BasePlane);
+
+        var values = _system.PlaneToNumbers(plane);
+
+        var FrameCode = new List<string>();
+        FrameCode.Add($"PR[9,1]={values[0]:0.000} ;");
+        FrameCode.Add($"PR[9,2]={values[1]:0.000} ;");
+        FrameCode.Add($"PR[9,3]={values[2]:0.000} ;");
+        FrameCode.Add($"PR[9,4]={values[5]:0.000} ;");
+        FrameCode.Add($"PR[9,5]={values[4]:0.000} ;");
+        FrameCode.Add($"PR[9,6]={values[3]:0.000} ;");
+        FrameCode.Add($"UFRAME[9]=PR[9] ;");
+        FrameCode.Add($"UFRAME_NUM=9 ;");
+ 
+        return FrameCode;
+    }
+}

--- a/src/Robots/RobotArms/RobotFanuc.cs
+++ b/src/Robots/RobotArms/RobotFanuc.cs
@@ -1,0 +1,38 @@
+using Rhino.Geometry;
+using static System.Math;
+using static Robots.Util;
+
+namespace Robots;
+
+public class RobotFanuc : RobotArm
+{
+    internal RobotFanuc(string model, double payload, Plane basePlane, Mesh baseMesh, Joint[] joints)
+        : base(model, Manufacturers.Fanuc, payload, basePlane, baseMesh, joints) { }
+    private protected override MechanismKinematics CreateSolver() => new SphericalWristKinematics(this);
+
+    public static double FanucDegreeToRadian(double degree, int i)
+    {
+        double radian = degree.ToRadians();
+        if (i == 1) radian = -radian + PI * 0.5;
+        if (i == 3) radian *= -1;
+        if (i == 5) radian *= -1;
+        return radian;
+    }
+
+    public override double DegreeToRadian(double degree, int i)
+    {
+        return FanucDegreeToRadian(degree, i);
+    }
+
+    public override double RadianToDegree(double radian, int i)
+    {
+        if (i == 1) { radian -= PI * 0.5; radian = -radian; }
+        if (i == 3) radian *= -1;
+        if (i == 5) radian *= -1;
+        return radian.ToDegrees();
+    }
+
+    protected override double[] DefaultAlpha => new[] { HalfPI, 0, HalfPI, -HalfPI, HalfPI, 0 };
+    protected override double[] DefaultTheta => new[] { 0, HalfPI, 0, 0, 0, 0 };
+    protected override int[] DefaultSign => new[] { 1, -1, -1, 1, -1, 1 };
+}

--- a/src/Robots/RobotSystems/RobotSystem.cs
+++ b/src/Robots/RobotSystems/RobotSystem.cs
@@ -4,7 +4,7 @@ using static Robots.Util;
 
 namespace Robots;
 
-public enum Manufacturers { ABB, KUKA, UR, Staubli, FrankaEmika, Doosan, Other, All };
+public enum Manufacturers { ABB, KUKA, UR, Staubli, FrankaEmika, Doosan, Fanuc, Other, All };
 
 public class DefaultPose(List<List<Plane>> planes, List<List<Mesh>> meshes)
 {

--- a/src/Robots/RobotSystems/SystemFanuc.cs
+++ b/src/Robots/RobotSystems/SystemFanuc.cs
@@ -1,0 +1,77 @@
+using Rhino.Geometry;
+
+namespace Robots;
+
+public class SystemFanuc : IndustrialSystem
+{
+    internal SystemFanuc(string name, List<MechanicalGroup> mechanicalGroups, IO io, Plane basePlane, Mesh? environment) : base(name, Manufacturers.Fanuc, mechanicalGroups, io, basePlane, environment)
+    {
+       
+    }
+
+    public static Plane QuaternionToPlane(double x, double y, double z, double q1, double q2, double q3, double q4)
+    {
+        var point = new Point3d(x, y, z);
+        var quaternion = new Quaternion(q1, q2, q3, q4);
+        return quaternion.ToPlane(point);
+    }
+
+    public static double[] PlaneToQuaternion(Plane plane)
+    {
+        var q = plane.ToQuaternion();
+        return [plane.OriginX, plane.OriginY, plane.OriginZ, q.A, q.B, q.C, q.D];
+    }
+
+    public override double[] PlaneToNumbers(Plane plane)
+    {
+        var t = plane.ToTransform();
+        var e = t.ToEulerZYX();
+        return [e.A1, e.A2, e.A3, e.A4.ToDegrees(), e.A5.ToDegrees(), e.A6.ToDegrees()];
+    }
+
+    public override Plane NumbersToPlane(double[] numbers)
+    {
+        var euler = new Vector6d(numbers[0], numbers[1], numbers[2], numbers[3].ToRadians(), numbers[4].ToRadians(), numbers[5].ToRadians());
+        var t = euler.EulerZYXToTransform();
+        return t.ToPlane();
+    }
+
+    internal override void SaveCode(IProgram program, string folder)
+    {
+        if (program.Code is null)
+            throw new InvalidOperationException(" Program code not generated");
+
+        Directory.CreateDirectory(Path.Combine(folder, program.Name));
+        bool multiProgram = program.MultiFileIndices.Count > 1;
+
+        for (int i = 0; i < program.Code.Count; i++)
+        {
+            {
+                string file = Path.Combine(folder, program.Name, $"{program.Name}.LS");
+                var code = program.Code[i][0];
+
+                if (!multiProgram)
+                {
+                    code = [.. code];
+                    code.AddRange(program.Code[i][1]);
+                }
+
+                var joinedCode = string.Join("\r\n", code);
+                File.WriteAllText(file, joinedCode);
+            }
+
+            if (multiProgram)
+            {
+                for (int j = 1; j < program.Code[i].Count; j++)
+                {
+                    int index = j - 1;
+                    string file = Path.Combine(folder, program.Name, $"{program.Name}_{index:000}.LS");
+                    var joinedCode = string.Join("\r\n", program.Code[i][j]);
+                    File.WriteAllText(file, joinedCode);
+                }
+            }
+        }
+    }
+
+    internal override List<List<List<string>>> Code(Program program) => new FanucPostProcessor(this, program).Code;
+}


### PR DESCRIPTION
This pull request adds a postprocessor for Fanuc robots.

I tried to follow the same code structure as the rest of the existing robots, but Fanuc robots have their peculiarities and I had to do some free styling on this:
- How joints angles are calculated: Fanuc robots measure the angle of the third joint with respect to the ground and not with respect to the second joint.
- The declaration and calling of variables. Fanuc directly uses memory registers. For the sake of simplicity I have avoided their use and instead have chosen to enter the value directly into functions such as SetAO and Wait.
- Joint type motions of Fanuc robots use a % of the maximum speed at which they can move instead of a value expressed in mm/s. Although it doesn't seem quite right to me, I have used the value of the Target component's speed input as a percentage. I don't think this is the best way to do it because in the component description it says that the units are in "mm/s" but I couldn't think of a better way to do it.
- The robot configurations are also somewhat problematic. I think I've found a way to relate them correctly, but I'm not 100% sure about it.
- Finally, Fanuc robots don't have the World coordinate frame at the bottom of the robot. Instead they have it positioned on the rotation axis of the first joint at the height of the rotation axis of the second joint (see [image](https://i.ytimg.com/vi/rQ3VD-7aih4/sddefault.jpg)) . This means that when working with Fanuc robots you have to create a Base Plane for the Load Robot component and position it at the height of the axis of the second joint.

The generated LS code has been tested on a real robot (M-20iB/35S with R-30iB Plus controller) to check that it works correctly.