### PR TITLE
Fix UR5e DH parameters

### DIFF
--- a/UniversalRobot.xml
+++ b/UniversalRobot.xml
@@ -26,12 +26,12 @@
       <RobotArm model="UR5e" manufacturer="UR" payload="5">
         <Base x="0.000" y="0.000" z="0.000" q1="1.000" q2="0.000" q3="0.000" q4="0.000" />
         <Joints>
-          <Revolute number="1" a="0" d="162.30" minrange="-360" maxrange="360" maxspeed="180" />
+          <Revolute number="1" a="0" d="162.5" minrange="-360" maxrange="360" maxspeed="180" />
           <Revolute number="2" a="-425" d="0" minrange="-360" maxrange="360" maxspeed="180" />
-          <Revolute number="3" a="-392.25" d="0" minrange="-360" maxrange="360" maxspeed="180" />
-          <Revolute number="4" a="0" d="133.30" minrange="-360" maxrange="360" maxspeed="180" />
-          <Revolute number="5" a="0" d="100.30" minrange="-360" maxrange="360" maxspeed="180" />
-          <Revolute number="6" a="0" d="99.60" minrange="-360" maxrange="360" maxspeed="180" />
+          <Revolute number="3" a="-392.2" d="0" minrange="-360" maxrange="360" maxspeed="180" />
+          <Revolute number="4" a="0" d="133.3" minrange="-360" maxrange="360" maxspeed="180" />
+          <Revolute number="5" a="0" d="99.7" minrange="-360" maxrange="360" maxspeed="180" />
+          <Revolute number="6" a="0" d="99.6" minrange="-360" maxrange="360" maxspeed="180" />
         </Joints>
       </RobotArm>
     </Mechanisms>


### PR DESCRIPTION
The parameters differed slightly from the values provided by UR  on their [DH Parameter website](https://www.universal-robots.com/articles/ur/application-installation/dh-parameters-for-calculations-of-kinematics-and-dynamics/#:~:text=0%2C%200%2C%200.0001%5D-,UR5e,-Kinematics)

These were the discrepancies: 
162.3 instead of 162.5
-392.25 instead of -392.2
100.3 instead of 99.7

The values are now in line with the official ones.  See this discussion for reference: 
https://github.com/visose/Robots/pull/209#issuecomment-2025925413