### PR TITLE
Added Kuka KR120 to libraries 

### DIFF
--- a/FH Muenster MSA.xml
+++ b/FH Muenster MSA.xml
@@ -1,0 +1,25 @@
+<RobotSystems>
+
+  <RobotCell name="KR120_R2700_2" manufacturer="KUKA">
+    <Mechanisms>
+      <RobotArm model="MSAKR120_R2700_2" manufacturer="KUKA" payload="120">
+        <Base x="0.000" y="0.000" z="0.000" q1="1.000" q2="0.000" q3="0.000" q4="0.000" />
+        <Joints>
+<Revolute number="1" a="330" d="645" minrange="-185" maxrange="185" maxspeed="120" />
+<Revolute number="2" a="1150" d="0" minrange="-140" maxrange="-5" maxspeed="115" />
+<Revolute number="3" a="115" d="0" minrange="-120" maxrange="168" maxspeed="120" />
+<Revolute number="4" a="0" d="1220" minrange="-350" maxrange="350" maxspeed="190" />
+<Revolute number="5" a="0" d="0" minrange="-125" maxrange="125" maxspeed="180" />
+<Revolute number="6" a="0" d="215" minrange="-350" maxrange="350" maxspeed="260" />
+        </Joints>
+      </RobotArm>
+    </Mechanisms>
+    <IO>
+      <DO names="1,2,3,4" />
+      <DI names="1,2,3,4" />
+      <AO names="1,2" />
+      <AI names="1,2" />
+    </IO>
+  </RobotCell>
+
+</RobotSystems>

--- a/FH Muenster MSA.xml
+++ b/FH Muenster MSA.xml
@@ -2,7 +2,7 @@
 
   <RobotCell name="KR120_R2700_2" manufacturer="KUKA">
     <Mechanisms>
-      <RobotArm model="MSAKR120_R2700_2" manufacturer="KUKA" payload="120">
+      <RobotArm model="KR120_R2700_2" manufacturer="KUKA" payload="120">
         <Base x="0.000" y="0.000" z="0.000" q1="1.000" q2="0.000" q3="0.000" q4="0.000" />
         <Joints>
 <Revolute number="1" a="330" d="645" minrange="-185" maxrange="185" maxspeed="120" />


### PR DESCRIPTION
## EN: KUKA KR120 Robot – FH Münster I MSA Münster School of Architecture

The KUKA KR120 R2700-2 robot, installed at MSA Münster (FH Münster), has been added as a custom robot to the library. The geometry is based on the official KUKA datasheet (freely available on the KUKA website). In particular, the `d` and `a` and DH parameters still need to be tested and validated in simulation. Source: https://www.kuka.com/-/media/kuka-downloads/imported/8350ff3ca11642998dbdc81dcc2ed44c/0000325899_de.pdf?rev=1715c3ee57fa4c2b8e455316f36d9407&hash=77C914F5026B56C75663D98FF38A1026

The permanently mounted plastic extruder (manufacturer: Weber) is not included in the robot model and must be added separately as a tool. Due to copyright restrictions, we are not allowed to share the extruder geometry.

The robot base position deviates slightly from the actual installation height to ensure general usability. For physical setups, users may need to lower the print table in the Z-direction accordingly.

The current use is strictly **for simulation purposes only** and has not yet been tested in real-world operation.

The model and geometry were downloaded from publicly available resources provided by KUKA.

There are plans to provide the full cell including a print table and a simplified tool model in the future.

*Feel free to suggest improvements or changes.*

---

## DE: KUKA KR120 Roboter – FH Münster I MSA Münster School of Architecture

Der KUKA KR120 R2700-2 Roboter, installiert an der MSA Münster (FH Münster), wurde als eigener Roboter der Library hinzugefügt. Die geometrische Basis des Modells basiert auf dem offiziellen KUKA-Datenblatt (öffentlich zugänglich auf der offiziellen KUKA Website). Besonders die DH Parameter für `d` und `a` müssen im nächsten Schritt innerhalb der Simulation getestet und ggf. angepasst werden. Quelle: https://www.kuka.com/-/media/kuka-downloads/imported/8350ff3ca11642998dbdc81dcc2ed44c/0000325899_de.pdf?rev=1715c3ee57fa4c2b8e455316f36d9407&hash=77C914F5026B56C75663D98FF38A1026

Der bei uns fest verbaute Kunststoffextruder (Hersteller: Weber) wurde nicht im Modell integriert, da dieser separat als Werkzeug eingebunden werden muss und aus urheberrechtlichen Gründen nicht zur Verfügung gestellt werden kann.

Die Roboterbasis weicht in der Höhe von der realen Installationshöhe leicht ab, damit das Modell allgemein nutzbar bleibt. Für reale Setups muss gegebenenfalls die Z-Position eines Drucktisches angepasst werden.

Die Roboterdaten dienen derzeit **ausschließlich der Simulation** und wurden noch nicht im Realbetrieb getestet.

Das Roboter-Modell basiert auf den öffentlich verfügbaren Unterlagen und Geometriedaten von KUKA.

Zukünftig ist geplant, die gesamte Zelle inkl. Drucktisch und ein vereinfachtes Werkzeugmodell bereitzustellen.

*Feedback und Verbesserungsvorschläge sind jederzeit willkommen.*

